### PR TITLE
Make pack.mcmeta valid

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "Just Enough Buttons Resources",
-        "pack_format": 4,
+        "pack_format": 4
     }
 }


### PR DESCRIPTION
Removed illegal trailing comma from last property in pack.mcmeta so that resources can be loaded.